### PR TITLE
fix: destrava o build Android e a inicialização em dev (restante da #6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Nenhuma dessas variáveis é obrigatória em desenvolvimento (__DEV__):
+# o app usa dados mockados para Supabase/PostHog e o login CAGR usa o fluxo mock.
+# Em builds de produção, todas são obrigatórias.
+
+# Supabase (https://supabase.com/dashboard → Project Settings → API)
+EXPO_PUBLIC_SUPABASE_URL=
+EXPO_PUBLIC_SUPABASE_ANON_KEY=
+
+# PostHog (https://app.posthog.com → Project Settings)
+EXPO_PUBLIC_POSTHOG_API_KEY=
+
+# OAuth CAGR/UFSC (secrets do ambiente de produção)
+EXPO_PUBLIC_CAGR_CLIENT_ID=
+EXPO_PUBLIC_CAGR_CLIENT_SECRET=
+EXPO_PUBLIC_CAGR_REDIRECT_URI=
+EXPO_PUBLIC_CAGR_STATE=

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -20,6 +20,11 @@ export {
 
 const queryClient = new QueryClient();
 
+// Em desenvolvimento o PostHog já roda com `disabled: true`, mas o provider lança
+// se `apiKey` for undefined. O placeholder permite iniciar o app sem .env.
+const posthogApiKey =
+  process.env.EXPO_PUBLIC_POSTHOG_API_KEY ?? (__DEV__ ? 'phc-dev-placeholder' : undefined);
+
 export default function RootLayout() {
   useInitialAndroidBarSync();
   const { colorScheme, isDarkColorScheme } = useColorScheme();
@@ -32,7 +37,7 @@ export default function RootLayout() {
       />
       <I18nextProvider i18n={i18n}>
         <PostHogProvider
-          apiKey={process.env.EXPO_PUBLIC_POSTHOG_API_KEY}
+          apiKey={posthogApiKey}
           options={{
             host: 'https://us.i.posthog.com',
             disabled: __DEV__,

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "nossa-ufsc",
@@ -85,6 +84,7 @@
     },
   },
   "patchedDependencies": {
+    "@react-native-menu/menu@1.2.4": "patches/@react-native-menu%2Fmenu@1.2.4.patch",
     "react-native-ios-utilities@5.2.0": "patches/react-native-ios-utilities@5.2.0.patch",
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -116,5 +116,5 @@
     "react-native-ios-utilities@5.2.0": "patches/react-native-ios-utilities@5.2.0.patch",
     "@react-native-menu/menu@1.2.4": "patches/@react-native-menu%2Fmenu@1.2.4.patch"
   },
-  "packageManager": "pnpm@10.31.0+sha512.e3927388bfaa8078ceb79b748ffc1e8274e84d75163e67bc22e06c0d3aed43dd153151cbf11d7f8301ff4acb98c68bdc5cadf6989532801ffafe3b3e4a63c268"
+  "packageManager": "bun@1.2.21"
 }

--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
   },
   "private": true,
   "patchedDependencies": {
-    "react-native-ios-utilities@5.2.0": "patches/react-native-ios-utilities@5.2.0.patch"
+    "react-native-ios-utilities@5.2.0": "patches/react-native-ios-utilities@5.2.0.patch",
+    "@react-native-menu/menu@1.2.4": "patches/@react-native-menu%2Fmenu@1.2.4.patch"
   },
   "packageManager": "pnpm@10.31.0+sha512.e3927388bfaa8078ceb79b748ffc1e8274e84d75163e67bc22e06c0d3aed43dd153151cbf11d7f8301ff4acb98c68bdc5cadf6989532801ffafe3b3e4a63c268"
 }

--- a/patches/@react-native-menu%2Fmenu@1.2.4.patch
+++ b/patches/@react-native-menu%2Fmenu@1.2.4.patch
@@ -1,0 +1,48 @@
+diff --git a/android/src/main/java/com/reactnativemenu/MenuView.kt b/android/src/main/java/com/reactnativemenu/MenuView.kt
+index 17ed7c6491b60e87fe829fb3f8841424617b4cfb..0c55452172975d695ba73d0d28d0f3add42e91af 100644
+--- a/android/src/main/java/com/reactnativemenu/MenuView.kt
++++ b/android/src/main/java/com/reactnativemenu/MenuView.kt
+@@ -47,11 +47,13 @@ class MenuView(private val mContext: ReactContext) : ReactViewGroup(mContext) {
+     prepareMenu()
+   }
+ 
+-  override fun setHitSlopRect(rect: Rect?) {
+-    super.setHitSlopRect(rect)
+-    mHitSlopRect = rect
+-    updateTouchDelegate()
+-  }
++  override var hitSlopRect: Rect?
++    get() = super.hitSlopRect
++    set(value) {
++      super.hitSlopRect = value
++      mHitSlopRect = value
++      updateTouchDelegate()
++    }
+ 
+   override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+     return true
+diff --git a/android/src/main/java/com/reactnativemenu/MenuViewManagerBase.kt b/android/src/main/java/com/reactnativemenu/MenuViewManagerBase.kt
+index 4731e1a1528a2de495cc2ae3156c813b64ec6832..e4d2743bd6a038b769c3cf34c68297a1fc44d109 100644
+--- a/android/src/main/java/com/reactnativemenu/MenuViewManagerBase.kt
++++ b/android/src/main/java/com/reactnativemenu/MenuViewManagerBase.kt
+@@ -123,9 +123,9 @@ abstract class MenuViewManagerBase : ReactClippingViewManager<MenuView>() {
+   fun setHitSlop(view: ReactViewGroup, @Nullable hitSlop: ReadableMap?) {
+     if (hitSlop == null) {
+       // We should keep using setters as `Val cannot be reassigned`
+-      view.setHitSlopRect(null)
++      view.hitSlopRect = null
+     } else {
+-      view.setHitSlopRect(
++      view.hitSlopRect = (
+               Rect(
+                       if (hitSlop.hasKey("left"))
+                               PixelUtil.toPixelFromDIP(hitSlop.getDouble("left")).toInt()
+@@ -206,7 +206,7 @@ abstract class MenuViewManagerBase : ReactClippingViewManager<MenuView>() {
+ 
+   @ReactProp(name = ViewProps.OVERFLOW)
+   fun setOverflow(view: ReactViewGroup, overflow: String?) {
+-    view.setOverflow(overflow)
++    view.overflow = overflow
+   }
+ 
+   @ReactProp(name = "backfaceVisibility")

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -2,8 +2,13 @@ import 'react-native-url-polyfill/auto';
 import { SupportedStorage, createClient } from '@supabase/supabase-js';
 import { MMKV } from 'react-native-mmkv';
 
-const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+// Em desenvolvimento o Supabase não é utilizado (os hooks retornam dados mockados),
+// mas o createClient roda no escopo do módulo e lança sem as variáveis de ambiente.
+// Valores placeholder permitem iniciar o app sem .env, conforme o README.
+const supabaseUrl =
+  process.env.EXPO_PUBLIC_SUPABASE_URL ?? (__DEV__ ? 'http://localhost:54321' : undefined);
+const supabaseAnonKey =
+  process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? (__DEV__ ? 'dev-placeholder-anon-key' : undefined);
 
 const storage = new MMKV({ id: 'supabase-storage' });
 


### PR DESCRIPTION
## Descrição

Resolve os itens restantes da #6 (o item 1 foi resolvido pela #7):

### 1. `@react-native-menu/menu` — patch para RN 0.86

O RN 0.86 converteu `ReactViewGroup.setHitSlopRect()` na propriedade Kotlin `hitSlopRect` e removeu `setOverflow`, quebrando `:react-native-menu_menu:compileDebugKotlin`. O upstream corrigiu na `master`, mas não publica release desde set/2025.

Seguindo a recomendação da própria issue, o fix é um `bun patch` sobre a **1.2.4** — consistente com o `patchedDependencies` já mantido para `react-native-ios-utilities@5.2.0`, e sem atravessar o major (o `zeego@3.0.6` declara peer em `@react-native-menu/menu@1.2.2`; a 2.0.0 também não compila no RN 0.86). O patch converte os três call sites e o override em `MenuView` para a sintaxe de propriedade. Auditei todas as demais chamadas a `ReactViewGroup` da lib contra o RN 0.86 — apenas essas duas APIs mudaram.

### 2. Inicialização em dev sem `.env`

O README afirma que em `__DEV__` Supabase e PostHog não são utilizados, mas `utils/supabase.ts` lançava `supabaseUrl is required` na avaliação do módulo e o `PostHogProvider` lançava sem `apiKey` — derrubando também as rotas do Expo Router (`missing the required default export`). Agora ambos usam placeholders **apenas em dev** (o PostHog já rodava com `disabled: __DEV__`); em produção a ausência de env continua falhando alto. Adicionado `.env.example` documentando as 7 variáveis `EXPO_PUBLIC_*`.

### 3. `packageManager` corrigido

O campo declarava `pnpm@10.31.0`, mas o repositório usa Bun (`bun.lock`, README). Isso também resolve a observação sobre `overrides`: o Bun lê o campo no nível raiz normalmente.

## Como Testar

1. `rm -rf node_modules android && bun install`
2. `bun run:android`
3. Sem `.env`, o app deve compilar, instalar e iniciar em modo dev

Verificado localmente (macOS, Bun 1.2.21, JDK 17): `app:assembleDebug` → **BUILD SUCCESSFUL in 1m 38s** com APK gerado; `tsc`, `eslint` e `prettier` limpos.

## Fora do escopo (follow-ups)

- **CI**: um workflow de build Android no push teria detectado as duas regressões — fica para PR separado.
- **pre-commit**: `bun test --pass-with-no-tests` ainda retorna 1 no Bun 1.2.21 quando não há arquivos de teste; todo commit exige `--no-verify`.

## Checklist
- [ ] Testes adicionados/atualizados — não há suíte de testes no projeto
- [x] Documentação atualizada — `.env.example`
- [x] Código segue os padrões do projeto

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)